### PR TITLE
Implement DailyCarGame page with API endpoints

### DIFF
--- a/client/pages/DailyCarGame.tsx
+++ b/client/pages/DailyCarGame.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+
+interface Options {
+  manufacturers: string[];
+  models: string[];
+  years: number[];
+}
+
+interface Guess {
+  manufacturer: string;
+  model: string;
+  year: number;
+}
+
+const LOCAL_KEY = 'daily-car-guesses';
+const LEVEL_KEY = 'daily-car-level';
+
+const DailyCarGame: React.FC = () => {
+  const [level, setLevel] = useState<number>(() => {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem(LEVEL_KEY) : null;
+    return saved ? Number(saved) : 1;
+  });
+  const [options, setOptions] = useState<Options>({ manufacturers: [], models: [], years: [] });
+  const [guess, setGuess] = useState<Guess>({ manufacturer: '', model: '', year: new Date().getFullYear() });
+  const [guesses, setGuesses] = useState<Guess[]>([]);
+  const [message, setMessage] = useState<string>('');
+
+  useEffect(() => {
+    fetch('/api/options')
+      .then(res => res.json())
+      .then(setOptions)
+      .catch(() => setOptions({ manufacturers: [], models: [], years: [] }));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const savedGuesses = localStorage.getItem(LOCAL_KEY);
+    if (savedGuesses) {
+      setGuesses(JSON.parse(savedGuesses));
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(guesses));
+  }, [guesses]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(LEVEL_KEY, String(level));
+  }, [level]);
+
+  const handleChange = (field: keyof Guess) => (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setGuess({ ...guess, [field]: field === 'year' ? Number(e.target.value) : e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/guess', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(guess),
+    });
+    const data = await res.json();
+    setGuesses([...guesses, guess]);
+    if (!data.correct) {
+      setLevel(level + 1);
+      setMessage('Try again!');
+    } else {
+      setMessage('Correct!');
+    }
+  };
+
+  return (
+    <div>
+      <h1>Daily Car Game</h1>
+      <img src={`/image/${level}`} alt={`zoom level ${level}`} />
+      <form onSubmit={handleSubmit}>
+        <select value={guess.manufacturer} onChange={handleChange('manufacturer')} required>
+          <option value="" disabled>Select manufacturer</option>
+          {options.manufacturers.map(m => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+        <select value={guess.model} onChange={handleChange('model')} required>
+          <option value="" disabled>Select model</option>
+          {options.models.map(m => (
+            <option key={m} value={m}>{m}</option>
+          ))}
+        </select>
+        <select value={guess.year} onChange={handleChange('year')} required>
+          <option value="" disabled>Select year</option>
+          {options.years.map(y => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+        <button type="submit">Guess</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+};
+
+export default DailyCarGame;

--- a/client/pages/api/guess.ts
+++ b/client/pages/api/guess.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const CORRECT = { manufacturer: 'Nissan', model: 'Skyline', year: 1999 };
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { manufacturer, model, year } = req.body || {};
+  const correct =
+    manufacturer === CORRECT.manufacturer &&
+    model === CORRECT.model &&
+    Number(year) === CORRECT.year;
+
+  res.status(200).json({ correct });
+}

--- a/client/pages/api/options.ts
+++ b/client/pages/api/options.ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    const filePath = path.join(process.cwd(), 'data', 'cars.json');
+    const data = JSON.parse(await fs.readFile(filePath, 'utf8')) as Array<{
+      manufacturer: string;
+      model: string;
+      year: number;
+    }>;
+
+    const manufacturers = Array.from(new Set(data.map(c => c.manufacturer))).sort();
+    const models = Array.from(new Set(data.map(c => c.model))).sort();
+    const years = Array.from(new Set(data.map(c => c.year))).sort((a, b) => a - b);
+
+    res.status(200).json({ manufacturers, models, years });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load options' });
+  }
+}

--- a/data/cars.json
+++ b/data/cars.json
@@ -1,0 +1,5 @@
+[
+  { "manufacturer": "Nissan", "model": "Skyline", "year": 1999 },
+  { "manufacturer": "Toyota", "model": "Supra", "year": 1998 },
+  { "manufacturer": "Honda", "model": "NSX", "year": 2005 }
+]


### PR DESCRIPTION
## Summary
- add `DailyCarGame` page with zoomed image and guessing form
- expose `/api/options` to provide dropdown choices
- add `/api/guess` to validate guesses and track zoom level

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d0c38af8832aaec31a44d3c98066